### PR TITLE
Adjust precipitation rate calculations for units

### DIFF
--- a/SHiELD/atmos_model.F90
+++ b/SHiELD/atmos_model.F90
@@ -1329,11 +1329,11 @@ subroutine apply_fluxes_from_IPD_to_Atmos ( Atmos )
 
         ! --- precip rate (kg/m**2/s)
         if ( IPD_Data(nb)%Sfcprop%srflag(ix) .lt. 0.5) then  ! rain (srflag = 0)
-          Atmos%lprec(i,j) = 1./IPD_Control%dtp * IPD_Data(nb)%Sfcprop%tprcp(ix)
+          Atmos%lprec(i,j) = 1./IPD_Control%dtp * IPD_Data(nb)%Sfcprop%tprcp(ix) * 1000.
           Atmos%fprec(i,j) = 0.
         else                                                 ! snow (srflag = 1)
           Atmos%lprec(i,j) = 0.
-          Atmos%fprec(i,j) = 1./IPD_Control%dtp * IPD_Data(nb)%Sfcprop%tprcp(ix)
+          Atmos%fprec(i,j) = 1./IPD_Control%dtp * IPD_Data(nb)%Sfcprop%tprcp(ix) * 1000.
         endif
      enddo
   enddo


### PR DESCRIPTION
`IPD_Data(nb)%Sfcprop%tprcp(ix)` is in m or (`kg/m^2 × 1e-3`). 
We add `*1000` to convert it to `kg/m^2`.
The final fields passed to the coupler, `Atmos%lprec` and `Atmos%fprec`, are in` kg/m^2/s` as expected by the land and ocean models.
NOTE: although some comments in the model suggest these field represent the accumulated rain quantity per time-step, they in fact represent the precipitation rate.